### PR TITLE
Handle big output from a process

### DIFF
--- a/src/macros/macros.scala
+++ b/src/macros/macros.scala
@@ -99,10 +99,18 @@ object Executor {
     val argsArray = args.to[Array]
     val proc = runtime.exec(argsArray, env.envArray, env.workDirFile)
 
+    var stdout = new StringBuffer
+    var stderr = new StringBuffer
+
+    while(proc.isAlive){
+      stdout.append(scala.io.Source.fromInputStream(proc.getInputStream).mkString.trim)
+      stderr.append(scala.io.Source.fromInputStream(proc.getErrorStream).mkString)
+    }
+
     Exit(
       proc.waitFor,
-      scala.io.Source.fromInputStream(proc.getInputStream).getLines.mkString("\n").trim,
-      scala.io.Source.fromInputStream(proc.getErrorStream)
+      stdout.toString,
+      scala.io.Source.fromString(stderr.toString)
     )
   }
 

--- a/src/tests/tests.scala
+++ b/src/tests/tests.scala
@@ -146,6 +146,19 @@ object Tests extends TestApp {
       sb.toString
     }.assert(_ == "125")
 
+    test("very long output") {
+       sh"python -c 'print str(0) *65536'".exec[Try[String]]
+    }.assert(x => x.isSuccess && x.get=="0"*65536)
+
+   test("error") {
+     sh"python -c 'import sys;sys.stderr.write(str(1234567));sys.exit(1)'".exec[Try[String]]
+   }.assert(x => {
+     val err = x.failed.get.asInstanceOf[ShellFailure].stderr
+     err.trim == "1234567"
+   }
+   )
+
     ()
   }
 }
+


### PR DESCRIPTION
waitFor was called before anything was read from streams. If streams
were full (65536 chars) then the process couldn't print output and
hanged.

closes propensive/fury#247